### PR TITLE
Use raw string for regex

### DIFF
--- a/pandas.ipynb
+++ b/pandas.ipynb
@@ -4876,7 +4876,7 @@
    ],
    "source": [
     "# many pandas string methods support regular expressions (regex)\n",
-    "orders.choice_description.str.replace('[\\[\\]]', '').head()"
+    "orders.choice_description.str.replace(r'[\\[\\]]', '').head()"
    ]
   },
   {

--- a/top_25_pandas_tricks.ipynb
+++ b/top_25_pandas_tricks.ipynb
@@ -2630,7 +2630,7 @@
     }
    ],
    "source": [
-    "pd.concat((pd.read_csv(file) for file in stock_files))"
+    "pd.concat(pd.read_csv(file) for file in stock_files)"
    ]
   },
   {


### PR DESCRIPTION
Hi :wave: - couple of nitpicks:
- if you're using a regular expression in `.str.replace`, it's probably safer to make it a raw string;
- there's an unnecessary set of brackets in the call to `pd.concat`

(found via `nqa pyupgrade pandas.ipynb --py36-plus --nbqa-mutate`)